### PR TITLE
Reduce memory request from vardict

### DIFF
--- a/templates/galaxy/config/job_conf.xml.j2
+++ b/templates/galaxy/config/job_conf.xml.j2
@@ -52,7 +52,7 @@
 		<tool id="canu" destination="condor_32-20"/>
 		<tool id="bowtie2" destination="condor_16"/>
 		<tool id="rna_star" destination="condor_90"/>
-		<tool id="vardict_java" destination="condor_64"/>
+		<tool id="vardict_java" destination="condor_32"/>
 	</tools>
 	<limits>
 		<limit type="registered_user_concurrent_jobs">4</limit>


### PR DESCRIPTION
When running jobs with VarDict it only used ~14 Gb RAM at max
![Capture](https://user-images.githubusercontent.com/38041391/151534739-787c6b38-5604-455d-97dd-cc374c17012f.PNG)
![Capture1](https://user-images.githubusercontent.com/38041391/151534740-f8d6a6dd-0879-43d4-9221-e388aa12ec7f.PNG)
![Capture2](https://user-images.githubusercontent.com/38041391/151534745-00bcc0a9-35a1-4465-8250-cac42d6d7be8.PNG)
.